### PR TITLE
chore: update golangci-lint to v2.13.1

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-29T13:52:15.336190123Z",
-  "version": "1.3.4",
+  "generated_at": "2026-08-22T14:51:02.668060784Z",
+  "version": "1.3.7",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Ghcr manifest
         id: ghcr
         if: github.event_name != 'pull_request'
-        uses: actionhippie/manifest@91ad515d3d7d08e8236d7c008cfb8a9f6b8caf56 # v1.9.0
+        uses: actionhippie/manifest@3a6f40c5b3deb413549b3ced0148245e95a01af4 # v1.9.1
         with:
           username: cbrgm
           password: ${{ secrets.BOT_PAT_TOKEN }}

--- a/.github/workflows/go-lint-test.yml
+++ b/.github/workflows/go-lint-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: "golangci-lint"
-          version: "2.11.4"
+          version: "2.13.1"
           download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${version}-linux-amd64.tar.gz"
           tarball_binary_path: "*/${binary}"
           smoke_test: "${binary} --version"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.26"
+  go: "1.27"
   modules-download-mode: readonly
   tests: false
 linters:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ifndef VERSION
 	ifeq ($(GITHUB_REF_TYPE), tag)
 		VERSION ?= $(subst v,,$(GITHUB_REF_NAME))
 	else
-		VERSION ?= $(shell git describe --tags --abbrev=0)-dirty
+		VERSION ?= $(shell git describe --tags --dirty 2>/dev/null || echo dev)
 	endif
 endif
 


### PR DESCRIPTION
chore: update golangci-lint to v2.13.1